### PR TITLE
ファームウェアのリンク先を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@
 Raspberry Pi Picoをキーボードとして使えるようにします。  
 こちらのファイルをダウンロードしてください。    
 - [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 
 Raspberry Pi PicoのBOOTSELボタン押しながらUSBケーブルでPCと接続すると、RPI-RP2というUSBメモリとして認識されます。    
 ![](img/IMG_4689.jpg)     

--- a/README_EN.md
+++ b/README_EN.md
@@ -81,7 +81,7 @@
 ## Write firmware
 Download uf2 file.
 - [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 
 Connect the Raspberry Pi Pico to the PC while holding down the BOOTSEL button, it will be recognized as a USB memory device called RPI-RP2.
 ![](img/IMG_4689.jpg)     

--- a/leftside/7_CUSTOM.md
+++ b/leftside/7_CUSTOM.md
@@ -19,8 +19,8 @@ Hold B（N）to move to utility layer.
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- Ball in BOTH Side [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ![](../img/custom/IMG_5884.jpg)  
 

--- a/leftside/7_CUSTOM.md
+++ b/leftside/7_CUSTOM.md
@@ -16,11 +16,11 @@ Hold B（N）to move to utility layer.
 
 
 - Ball in LEFT Side [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ![](../img/custom/IMG_5884.jpg)  
 
@@ -41,9 +41,9 @@ Hold 5（6）or use trackball to move to RGB setteing layer.
 ## Using VIA
 Download JSON File.
 - SOLO [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - DUO [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 
 Access VIA.
@@ -55,7 +55,7 @@ Load JSON.
 
 ### Save and restore keymap
 ![](../img/custom/load.png)  
-- sample keymap [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
+- sample keymap [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
 
 
 ### Change layout

--- a/leftside/8_MISC.md
+++ b/leftside/8_MISC.md
@@ -17,8 +17,8 @@
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - DUO Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 
 ## JSON for VIA

--- a/leftside/8_MISC.md
+++ b/leftside/8_MISC.md
@@ -12,26 +12,26 @@
 
 ## Firmware
 - SOLO [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 - DUO Ball in LEFT Side [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - DUO Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 
 ## JSON for VIA
 
 - SOLO [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - DUO [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 ## Sample Keymaps
-- SOLO LEFT Side [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
-- SOLO RIGHT Side [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_right.layout.json)
-- DUO defaulte kymap [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+- SOLO LEFT Side [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
+- SOLO RIGHT Side [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_right.layout.json)
+- DUO defaulte kymap [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
 
 ## Firmware Codes
 - https://github.com/Taro-Hayashi/qmk_firmware/tree/tarohayashi/keyboards/tarohayashi/killerwhale/

--- a/rightside/7_CUSTOM.md
+++ b/rightside/7_CUSTOM.md
@@ -19,8 +19,8 @@ Hold B（N）to move to utility layer.
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- Ball in BOTH Side [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ![](../img/custom/IMG_5884.jpg)  
 

--- a/rightside/7_CUSTOM.md
+++ b/rightside/7_CUSTOM.md
@@ -16,11 +16,11 @@ Hold B（N）to move to utility layer.
 
 
 - Ball in LEFT Side [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ![](../img/custom/IMG_5884.jpg)  
 
@@ -41,9 +41,9 @@ Hold 5（6）or use trackball to move to RGB setteing layer.
 ## Using VIA
 Download JSON File.
 - SOLO [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - DUO [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 
 Access VIA.
@@ -55,7 +55,7 @@ Load JSON.
 
 ### Save and restore keymap
 ![](../img/custom/load.png)  
-- sample keymap [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
+- sample keymap [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
 
 
 ### Change layout

--- a/rightside/8_MISC.md
+++ b/rightside/8_MISC.md
@@ -17,8 +17,8 @@
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - DUO Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 
 ## JSON for VIA

--- a/rightside/8_MISC.md
+++ b/rightside/8_MISC.md
@@ -12,26 +12,26 @@
 
 ## Firmware
 - SOLO [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 - DUO Ball in LEFT Side [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - DUO Ball in RIGHT Side [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - DUO Ball in BOTH Side [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 
 ## JSON for VIA
 
 - SOLO [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - DUO [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 ## Sample Keymaps
-- SOLO LEFT Side [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
-- SOLO RIGHT Side [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_right.layout.json)
-- DUO defaulte kymap [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+- SOLO LEFT Side [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
+- SOLO RIGHT Side [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_right.layout.json)
+- DUO defaulte kymap [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
 
 ## Firmware Codes
 - https://github.com/Taro-Hayashi/qmk_firmware/tree/tarohayashi/keyboards/tarohayashi/killerwhale/

--- a/右手用/7_カスタマイズ.md
+++ b/右手用/7_カスタマイズ.md
@@ -23,11 +23,11 @@
 
 #### ※左右間のケーブルを着け外しする前には必ずUSBケーブルを抜いてください。先にTRRSケーブルを抜き差しするとRaspberry Pi Picoが壊れることがあります。
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ※USBを繋がない側のボールはカーソルが少し遅くなります  
 ※トラックボールを使用しない場合はどれでも大丈夫です。
@@ -62,9 +62,9 @@
 こちらのJSONファイルをダウンロードしてください。
 
 - 単体使用向け [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - 左右分割向け [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 
 Google Chrome（Microsoft Edge）を利用して下記webサイトにアクセスするか、VIAのアプリケーションをダウンロードして起動してください。  
@@ -83,8 +83,8 @@ CONFIGUREタブのAuthorize device+からKiller Whale SOLO\DUOを追加してく
 VIAで設定したキーマップは保存、復元することができます。ファームウェアを入れ替えると初期化されるので保存しておくと便利です。
 ![](../img/custom/load.png)  
 右手専用のサンプルキーマップを用意したのでベースとしてお使いください。
-- 単体使用 右手専用キーマップ[solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_right.layout.json)
-- 左右分割 デフォルトキーマップ [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+- 単体使用 右手専用キーマップ[solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_right.layout.json)
+- 左右分割 デフォルトキーマップ [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
 
 ### 左右の変更（単体使用時）
 LAYOUTSから見た目の左右を変更することができます。  

--- a/右手用/7_カスタマイズ.md
+++ b/右手用/7_カスタマイズ.md
@@ -26,8 +26,8 @@
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- 左右分割 両手ボール [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ※USBを繋がない側のボールはカーソルが少し遅くなります  
 ※トラックボールを使用しない場合はどれでも大丈夫です。

--- a/右手用/8_その他.md
+++ b/右手用/8_その他.md
@@ -12,40 +12,40 @@
 ## ファームウェアまとめ（更新日: 2023/8/24）
 完成後にファームウェアを入れ替えたくなった場合はこちらからもダウンロード可能です。  
 - 単体使用 [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 レイヤーや各種Lockで発光が変わるファームウェアはこちら
 - 単体使用 [tarohayashi_killerwhale_solo_default_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default_layer.uf2)
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft_layer.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright_layer.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball_layer.uf2)
 
 
 ## VIA用JSONファイル（更新日: 2023/8/9）
 - 単体使用向け [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - 左右分割向け [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 ## VIA用サンプルキーマップ
 - 単体使用 左手専用+クリスタレイヤーキーマップ
-   - [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
+   - [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
      ![](../img/keymap/solo-left.jpg)  
 - 単体使用 右手専用キーマップ
-   - [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_right.layout.json)
+   - [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_right.layout.json)
      ![](../img/keymap/solo-right.jpg)
 - 左右分割 デフォルトキーマップ
-   - [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+   - [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
     ![](../img/keymap/duo-default.jpg)
 - 左右分割 [すとのふさん作](https://twitter.com/ld50themetaler/status/1691378802365214720?s=20)qwerty用キーマップ
    - https://github.com/ld50themetaler/etc/blob/main/killer_whale_duo.layout_20230815_30%25_qwerty_style.json
@@ -106,7 +106,7 @@ GitHubのファイルはこちらをクリックするとダウンロードで�
 - 分割キーボードでUSBを繋げない側が動かない
    - Raspberry Pi Picoの左右通信用のピンが壊れている可能性があります。
      こちらのテスト用ファームウェアを導入して画像の青どうし、黄色どうしをピンセット等で繋いでみて、"A"と入力されたら正常に動作しています。入力されなかった場合は故障していますので交換していただくか、左右別々にUSBに繋いでご利用いただくこともできます。
-      - [tarohayashi_killerwhale_trrstest_default.uf2](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_trrstest_default.uf2)
+      - [tarohayashi_killerwhale_trrstest_default.uf2](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_trrstest_default.uf2)
         ![](../img/custom/IMG_7353.jpg)
 - ジョイスティックが動かない
   - 左右分割キーボードとして使う場合、ジョイスティックはUSBケーブルを繋いだ側だけが動作します。  

--- a/左手用/7_カスタマイズ.md
+++ b/左手用/7_カスタマイズ.md
@@ -26,8 +26,8 @@
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
 ](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
-- 左右分割 両手ボール [tarohayashi_killerwhale_duo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_default.uf2)
+- 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
+](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ※USBを繋がない側のボールはカーソルが少し遅くなります  
 ※トラックボールを使用しない場合はどれでも大丈夫です。

--- a/左手用/7_カスタマイズ.md
+++ b/左手用/7_カスタマイズ.md
@@ -23,11 +23,11 @@
 
 #### ※左右間のケーブルを着け外しする前には必ずUSBケーブルを抜いてください。先にTRRSケーブルを抜き差しするとRaspberry Pi Picoが壊れることがあります。
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 ※USBを繋がない側のボールはカーソルが少し遅くなります  
 ※トラックボールを使用しない場合はどれでも大丈夫です。
@@ -62,9 +62,9 @@
 こちらのJSONファイルをダウンロードしてください。
 
 - 単体使用向け [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - 左右分割向け [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 
 Google Chrome（Microsoft Edge）を利用して下記webサイトにアクセスするか、VIAのアプリケーションをダウンロードして起動してください。  
@@ -81,8 +81,8 @@ CONFIGUREタブのAuthorize device+からKiller Whale SOLO\DUOを追加してく
 VIAで設定したキーマップは保存、復元することができます。ファームウェアを入れ替えると初期化されるので保存しておくと便利です。
 ![](../img/custom/load.png)  
 左手専用のサンプルキーマップを用意したのでベースとしてお使いください。
-- 単体使用 左手専用キーマップ[solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
-- 左右分割 デフォルトキーマップ [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+- 単体使用 左手専用キーマップ[solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
+- 左右分割 デフォルトキーマップ [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
 
 
 ### 左右の変更（単体使用時）

--- a/左手用/8_その他.md
+++ b/左手用/8_その他.md
@@ -13,40 +13,40 @@
 ## ファームウェアまとめ（更新日: 2023/8/24）
 完成後にファームウェアを入れ替えたくなった場合はこちらからもダウンロード可能です。  
 - 単体使用 [tarohayashi_killerwhale_solo_default.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default.uf2)
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball.uf2)
 
 レイヤーや各種Lockで発光が変わるファームウェアはこちら
 - 単体使用 [tarohayashi_killerwhale_solo_default_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_solo_default_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_solo_default_layer.uf2)
 - 左右分割 左手ボール [tarohayashi_killerwhale_duo_ballleft_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballleft_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballleft_layer.uf2)
 - 左右分割 右手ボール [tarohayashi_killerwhale_duo_ballright_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_ballright_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_ballright_layer.uf2)
 - 左右分割 両手ボール [tarohayashi_killerwhale_duo_doubleball_layer.uf2
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_duo_doubleball_layer.uf2)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_duo_doubleball_layer.uf2)
 
 ## VIA用JSONファイル（更新日: 2023/8/9）
 
 - 単体使用向け [killer_whale_solo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_solo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_solo.json)
 - 左右分割向け [killer_whale_duo.json
-](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.json)
+](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.json)
 
 ## VIA用サンプルキーマップ
 - 単体使用 左手専用+クリスタレイヤーキーマップ
-   - [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_left.layout.json)
+   - [solo_left.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_left.layout.json)
      ![](../img/keymap/solo-left.jpg)  
 - 単体使用 右手専用キーマップ
-   - [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/solo_right.layout.json)
+   - [solo_right.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/solo_right.layout.json)
      ![](../img/keymap/solo-right.jpg)
 - 左右分割 デフォルトキーマップ
-   - [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/killer_whale_duo.layout.json)
+   - [killer_whale_duo.layout.json](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/killer_whale_duo.layout.json)
     ![](../img/keymap/duo-default.jpg)
 - 左右分割 [すとのふさん作](https://twitter.com/ld50themetaler/status/1691378802365214720?s=20)qwerty用キーマップ
    - https://github.com/ld50themetaler/etc/blob/main/killer_whale_duo.layout_20230815_30%25_qwerty_style.json
@@ -106,7 +106,7 @@ GitHubのファイルはこちらをクリックするとダウンロードで�
   - ジャンパーの指定が間違っている可能性があります。
 - 分割キーボードでUSBを繋げない側が動かない
    - Raspberry Pi Picoの左右通信用のピンが壊れている可能性があります。こちらのテスト用ファームウェアを導入して画像の青どうし、黄色どうしをピンセット等で繋いでみて、"A"と入力されたら正常に動作しています。入力されなかった場合は故障していますので交換していただくか、左右別々にUSBに繋いでご利用いただくこともできます。
-      - [tarohayashi_killerwhale_trrstest_default.uf2](https://github.com/Taro-Hayashi/KillerWhale/releases/download/0.21.7/tarohayashi_killerwhale_trrstest_default.uf2)
+      - [tarohayashi_killerwhale_trrstest_default.uf2](https://github.com/Taro-Hayashi/KillerWhale/releases/latest/download/tarohayashi_killerwhale_trrstest_default.uf2)
         ![](../img/custom/IMG_7353.jpg)
 - ジョイスティックが動かない
   - 左右分割キーボードとして使う場合、ジョイスティックはUSBケーブルを繋いだ側だけが動作します。  


### PR DESCRIPTION
丁寧なビルドガイドをありがとうございます。
リンクが切れてる箇所があったので修正しました。

1. 両手ボールのファームウェアが `tarohayashi_killerwhale_duo_default.uf2` から `tarohayashi_killerwhale_duo_doubleball.uf2` になっていてリンクが切れていたので修正しました。
2. ついでにダウンロードリンクを常に最新のリリースのものを参照するように修正しました。

2 については不要でしたら戻します:bow: